### PR TITLE
Update esp-knx-ip.h

### DIFF
--- a/esp-knx-ip.h
+++ b/esp-knx-ip.h
@@ -26,7 +26,9 @@
 
 // Webserver related
 #define USE_BOOTSTRAP             1 // [Default 1] Set to 1 to enable use of bootstrap CSS for nicer webconfig. CSS is loaded from bootstrapcdn.com. Set to 0 to disable
-#define ROOT_PREFIX               ""  // [Default ""] This gets prepended to all webserver paths, default is empty string "". Set this to "/knx" if you want the config to be available on http://<ip>/knx
+#ifndef ROOT_PREFIX
+  #define ROOT_PREFIX             ""  // [Default ""] This gets prepended to all webserver paths, default is empty string "". Set this to "/knx" if you want the config to be available on http://<ip>/knx
+#endif
 
 // These values normally don't need adjustment
 #define MULTICAST_PORT            3671 // [Default 3671]
@@ -512,7 +514,7 @@ class ESPKNXIP {
     feedback_id_t registered_feedbacks;
     feedback_t feedbacks[MAX_FEEDBACKS];
 
-    uint16_t ntohs(uint16_t);
+    uint16_t __ntohs(uint16_t);
 };
 
 // Global "singleton" object


### PR DESCRIPTION
Added `#ifndef ROOT_PREFIX` to have the option to set the **Root Prefix** before calling the `#include <esp-knx-ip.h>`, so as to eliminate the need of modifying the library.

Changing the name of **ntohs** to **__ntohs** to eliminate conflict when using ESP8266 LWIP library.