### PR TITLE
Eliminate compilation warning

### DIFF
--- a/esp-knx-ip.h
+++ b/esp-knx-ip.h
@@ -301,7 +301,7 @@ typedef uint8_t feedback_id_t;
 
 typedef struct __option_entry
 {
-  char *name;
+  const char *name;
   uint8_t value;
 } option_entry_t;
 


### PR DESCRIPTION
solved compilation warning:

warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]