### PR TITLE
Change defaults on esp-knx-ip.h

### DIFF
--- a/esp-knx-ip.h
+++ b/esp-knx-ip.h
@@ -22,7 +22,7 @@
 #define MAX_FEEDBACKS             20 // [Default 20] Maximum number of feedbacks that can be shown
 
 // Callbacks
-#define ALLOW_MULTIPLE_CALLBACKS_PER_ADDRESS  0 // [Default 0] Set to 1 to always test all assigned callbacks. This allows for multiple callbacks being assigned to the same address. If disabled, only the first assigned will be called.
+#define ALLOW_MULTIPLE_CALLBACKS_PER_ADDRESS  1 // [Default 0] Set to 1 to always test all assigned callbacks. This allows for multiple callbacks being assigned to the same address. If disabled, only the first assigned will be called.
 
 // Webserver related
 #define USE_BOOTSTRAP             1 // [Default 1] Set to 1 to enable use of bootstrap CSS for nicer webconfig. CSS is loaded from bootstrapcdn.com. Set to 0 to disable
@@ -37,7 +37,7 @@
 #define SEND_CHECKSUM             0
 
 // Uncomment to enable printing out debug messages.
-#define ESP_KNX_DEBUG
+//#define ESP_KNX_DEBUG
 /**
  * END CONFIG
  */


### PR DESCRIPTION
For compatibility with Scenes (that in some configurations uses several Group Addresses) `ALLOW_MULTIPLE_CALLBACKS_PER_ADDRESS` should be 1.

As this library is being used in other projects, `ESP_KNX_DEBUG` should be commented.