### PR TITLE
Correct invalid keywords.txt KEYWORD_TOKENTYPE

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,11 +1,11 @@
 # datatypes
-address_t	DATA_TYPE
-callback_id_t	DATA_TYPE
-callback_assignment_id_t	DATA_TYPE
-config_id_t	DATA_TYPE
-enable_condition_t	DATA_TYPE
-callback_fptr_t	DATA_TYPE
-knx_command_type_t	DATA_TYPE
+address_t	KEYWORD1		DATA_TYPE
+callback_id_t	KEYWORD1		DATA_TYPE
+callback_assignment_id_t	KEYWORD1		DATA_TYPE
+config_id_t	KEYWORD1		DATA_TYPE
+enable_condition_t	KEYWORD1		DATA_TYPE
+callback_fptr_t	KEYWORD1		DATA_TYPE
+knx_command_type_t	KEYWORD1		DATA_TYPE
 
 # methods
 setup	KEYWORD2
@@ -82,13 +82,13 @@ answer_4byte_int	KEYWORD2
 answer_4byte_uint	KEYWORD2
 answer_4byte_float	KEYWORD2
 
-data_to_1byte_int	KEYWORD 2
-data_to_2byte_int	KEYWORD 2
-data_to_2byte_float	KEYWORD 2
-data_to_4byte_float	KEYWORD 2
-data_to_3byte_color	KEYWORD 2
-data_to_3byte_time	KEYWORD 2
-data_to_3byte_data	KEYWORD 2
+data_to_1byte_int	KEYWORD2
+data_to_2byte_int	KEYWORD2
+data_to_2byte_float	KEYWORD2
+data_to_4byte_float	KEYWORD2
+data_to_3byte_color	KEYWORD2
+data_to_3byte_time	KEYWORD2
+data_to_3byte_data	KEYWORD2
 
 # constants
 knx	LITERAL1


### PR DESCRIPTION
The DATA_TYPE keyword identifier is only valid when used in the RSYNTAXTEXTAREA_TOKENTYPE field of keywords.txt. That is the fourth field rather than the second, where DATA_TYPE was previously. I moved DATA_TYPE to the fourth field and replaced it with the equivalent KEYWORD1 KEYWORD_TOKENTYPE in the second field.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype