### PR TITLE
Remove additional_info data structure

### DIFF
--- a/esp-knx-ip-send.cpp
+++ b/esp-knx-ip-send.cpp
@@ -29,7 +29,6 @@ void ESPKNXIP::send(address_t const &receiver, knx_command_type_t ct, uint8_t da
 	knx_pkt->total_len.len = __ntohs(len);
 	cemi_msg_t *cemi_msg = (cemi_msg_t *)knx_pkt->pkt_data;
 	cemi_msg->message_code = KNX_MT_L_DATA_IND;
-	cemi_msg->additional_info_len = 0;
 	cemi_service_t *cemi_data = &cemi_msg->data.service_information;
 	cemi_data->control_1.bits.confirm = 0;
 	cemi_data->control_1.bits.ack = 0;

--- a/esp-knx-ip.cpp
+++ b/esp-knx-ip.cpp
@@ -384,13 +384,7 @@ void ESPKNXIP::__loop_knx()
   if (cemi_msg->message_code != KNX_MT_L_DATA_IND)
     return;
 
-  DEBUG_PRINT(F("ADDI: 0x"));
-  DEBUG_PRINTLN(cemi_msg->additional_info_len, 16);
-
   cemi_service_t *cemi_data = &cemi_msg->data.service_information;
-
-  if (cemi_msg->additional_info_len > 0)
-    cemi_data = (cemi_service_t *)(((uint8_t *)cemi_data) + cemi_msg->additional_info_len);
 
   DEBUG_PRINT(F("C1: 0x"));
   DEBUG_PRINTLN(cemi_data->control_1.byte, 16);

--- a/esp-knx-ip.h
+++ b/esp-knx-ip.h
@@ -253,10 +253,8 @@ typedef struct __cemi_service
 typedef struct __cemi_msg
 {
   uint8_t message_code;
-  uint8_t additional_info_len;
   union
   {
-    cemi_addi_t additional_info[];
     cemi_service_t service_information;
   } data;
 } cemi_msg_t;


### PR DESCRIPTION
Prior to this change `esp-knx-ip` did not compile for me in Arduino 1.8.19 on macOS Monterey. The build failed with 

```c
In file included from /path/to/Project.ino:1:
esp-knx-ip.h:259:17: error: flexible array member in union
  259 |     cemi_addi_t additional_info[];
      |                 ^~~~~~~~~~~~~~~
exit status 1
flexible array member in union
```

In addition to that the `additional_info` array does not seem to be actively used anywhere in the code. So all in all this change seems fine to me.